### PR TITLE
@options.fetch(:errors, {}) can be nil

### DIFF
--- a/lib/bh/core_ext/rails/form/base_helper.rb
+++ b/lib/bh/core_ext/rails/form/base_helper.rb
@@ -75,7 +75,7 @@ module Bh
       def show_error_icon?(field_type, errors, suffix = nil)
         no_icon = %w(checkbox number_field radio_button select legend)
         hide = no_icon.include?(field_type.to_s)
-        errors.any? && @options.fetch(:errors, {}).fetch(:icons, true) && !hide && suffix.nil?
+        errors.any? && (@options.fetch(:errors) || {}).fetch(:icons, true) && !hide && suffix.nil?
       end
 
       def error_icon_tag


### PR DESCRIPTION
If the key `:errors` exists in `@options` then the previous code will return `nil`.

Changing it like this ensures we have a hash if errors did not exist or if it was nil.
